### PR TITLE
Add python3 classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,10 @@ setup(
       'Development Status :: 3 - Alpha',
       'License :: OSI Approved :: MIT License',
       'Programming Language :: Python :: 2.7',
+      'Programming Language :: Python :: 3.2',
+      'Programming Language :: Python :: 3.3',
+      'Programming Language :: Python :: 3.4',
+      'Programming Language :: Python :: 3.5',
       'Topic :: Office/Business :: Scheduling'
     ],
     keywords='business working time timedelta hours businesstime businesshours',


### PR DESCRIPTION
From .travis.yml file I see the code it's tested on python 3.2, 3.3, 3.4 3.5 and development versions, but this is not indicated on setup.py so it is not shown on pypi. 

This pull request adds the required classifiers on setup.py, so the data will be correctly shown when a new version will be uploaded. 