### PR TITLE
Allow to return final period with exacts deltas

### DIFF
--- a/businesstimedelta/businesstimedelta.py
+++ b/businesstimedelta/businesstimedelta.py
@@ -13,8 +13,9 @@ def localize_unlocalized_dt(dt):
 
 
 class BusinessTimeDelta(object):
-    def __init__(self, rule, hours=0, seconds=0, timedelta=None):
+    def __init__(self, rule, hours=0, seconds=0, timedelta=None, include_final=False):
         self.rule = rule
+        self.include_final = include_final
 
         if timedelta:
             self.timedelta = timedelta
@@ -42,6 +43,8 @@ class BusinessTimeDelta(object):
 
                 # If we ran out of timedelta, return
                 if period_delta > td_left:
+                    if self.include_final and not td_left:
+                        return dt
                     return period_start + td_left
 
                 td_left -= period_delta
@@ -65,6 +68,8 @@ class BusinessTimeDelta(object):
 
                 # If we ran out of timedelta, return
                 if period_delta > td_left:
+                    if self.include_final and not td_left:
+                        return dt
                     return period_end - td_left
 
                 td_left -= period_delta

--- a/businesstimedelta/test/businesstimedelta_tests.py
+++ b/businesstimedelta/test/businesstimedelta_tests.py
@@ -34,6 +34,20 @@ class BusinessTimeDeltaTest(unittest.TestCase):
             self.utc.localize(datetime.datetime(2016, 1, 26, 13, 0, 0))
         )
 
+    def test_add_exactly_one_period(self):
+        td = BusinessTimeDelta(self.workdayrule, hours=8)
+        dt = self.utc.localize(datetime.datetime(2016, 6, 17, 9, 0, 0))
+
+        self.assertEqual(
+            dt + td,
+            self.utc.localize(datetime.datetime(2016, 6, 20, 9, 0, 0))
+        )
+        td = BusinessTimeDelta(self.workdayrule, hours=8, include_final=True)
+        self.assertEqual(
+            dt + td,
+            self.utc.localize(datetime.datetime(2016, 6, 17, 17, 0, 0))
+        )
+
     def test_subtract_less_than_one_period(self):
         td = BusinessTimeDelta(self.workdayrule, hours=2)
         dt = self.utc.localize(datetime.datetime(2016, 1, 25, 11, 14, 0))
@@ -41,6 +55,23 @@ class BusinessTimeDeltaTest(unittest.TestCase):
         self.assertEqual(
             dt - td,
             self.utc.localize(datetime.datetime(2016, 1, 25, 9, 14, 0))
+        )
+
+    def test_subtract_exactly_one_period(self):
+        td = BusinessTimeDelta(self.workdayrule, hours=8)
+        dt = self.utc.localize(datetime.datetime(2016, 1, 25, 17, 0, 0))
+
+        self.assertEqual(
+            dt - td,
+            self.utc.localize(datetime.datetime(2016, 1, 22, 17, 0, 0))
+        )
+
+        td = BusinessTimeDelta(self.workdayrule, hours=8, include_final=True)
+        dt = self.utc.localize(datetime.datetime(2016, 1, 25, 17, 0, 0))
+
+        self.assertEqual(
+            dt - td,
+            self.utc.localize(datetime.datetime(2016, 1, 25, 9, 0, 0))
         )
 
     def test_subtract_more_than_one_period(self):


### PR DESCRIPTION
Hi All, 

## Feature details

When planning tasks, it's common to define that a task spends all the
working day (i.e: 8 hours), so when computing the final date with a
business delta of all the working hours and the start of the day it's expected
to return the final period and not the next start period.

Have a look at the tests for some examples and let me know if something is not clear.

### Implementation Discussion

- By default the old behaviour is preserved, so I'm wondering if the new behaviour can be activated by default.
- May the old behaviour considered as a bug and use the new behaviour by default? 
- Please feel free to propose better names for the variables

I added some basic testing, let me now if you think more exhaustive testing is required.

Let me know if you think that the case should be added to README. 

Thanks in advance for your time. 
