### PR TITLE
Fix TypeError on businesstimedelta.difference with Holiday Rules

### DIFF
--- a/businesstimedelta/rules/holidayrules.py
+++ b/businesstimedelta/rules/holidayrules.py
@@ -37,7 +37,7 @@ class HolidayRule(Rule):
 
             count += 1
             if count > max_days:
-                return None
+                return datetime
 
     def next(self, dt, reverse=False):
         """Get the start and end of the next holiday after a datetime

--- a/businesstimedelta/rules/holidayrules.py
+++ b/businesstimedelta/rules/holidayrules.py
@@ -37,7 +37,7 @@ class HolidayRule(Rule):
 
             count += 1
             if count > max_days:
-                return datetime
+                return datetime.date(9999, 12, 31)
 
     def next(self, dt, reverse=False):
         """Get the start and end of the next holiday after a datetime


### PR DESCRIPTION
When using a holiday rule, if the end date supplied when calling businesstimedelta.difference is greater than the last holiday for the rule, the HolidayRule.next_holiday method returns None leading to a TypeError when datetime.combine is called in the HolidayRule.next method. 

This change fixes this issue by returning a date that is not plausibly used 9999-12-31.